### PR TITLE
Structify candidate info temp storage (includes previous renaming pull request)

### DIFF
--- a/cfastforest.cpp
+++ b/cfastforest.cpp
@@ -59,11 +59,11 @@ float* FastForest::predict(float *rows, int n, int c) {
 
 
 void FastTree::clearStorage_() {
-    _mm_free(lT2); _mm_free(lT); _mm_free(lC); _mm_free(cutvals); _mm_free(cutidxs);
+    _mm_free(leftSqrTarget); _mm_free(leftTarget); _mm_free(leftCount); _mm_free(cutvals); _mm_free(cutidxs);
 }
 
 void FastTree::reset(int ncandidates) {
-    for (int i = 0; i < ncandidates; i++) { lT2[i]=lT[i]=lC[i] = 0; }
+    for (int i = 0; i < ncandidates; i++) { leftSqrTarget[i]=leftTarget[i]=leftCount[i] = 0; }
 }
 
 FastTree::FastTree(FastForest* parent) {
@@ -79,10 +79,10 @@ FastTree::FastTree(FastForest* parent) {
     int ncandidates = usedN * sqrt(c) / CUTOFF_DIVISOR;
     if (ncandidates < 4) ncandidates = 4;
     //printf("nc %d\n",nc);
-    lT = (float*)_mm_malloc(ncandidates * sizeof(float), 64);
-    lT2 = (float*)_mm_malloc(ncandidates * sizeof(float), 64);
+    leftTarget = (float*)_mm_malloc(ncandidates * sizeof(float), 64);
+    leftSqrTarget = (float*)_mm_malloc(ncandidates * sizeof(float), 64);
     cutvals = (float*)_mm_malloc(ncandidates * sizeof(float), 64);
-    lC = (int*)_mm_malloc(ncandidates * sizeof(int), 64);
+    leftCount = (int*)_mm_malloc(ncandidates * sizeof(int), 64);
     cutidxs = (int*)_mm_malloc(ncandidates * sizeof(int), 64);
 
 	buildNodes_();
@@ -203,23 +203,23 @@ void FastTree::bestCutoff_(Node *node) {
         sumTarget += y[r]; sumSqrTarget += y[r]*y[r];
     }
     //printf("n %d start %d pn %d ncandidates %d sumTarget %d usedN %d MAXN %d c %d\n", n, start, parent->n, ncandidates, sumTarget, usedN, MAXN, c);
-    //for (int i=0; i<ncandidates; i++) printf("lt %f cutvals %f lc %d cutidxs %d\n", lT[i], cutvals[i], lC[i], cutidxs[i]);
+    //for (int i=0; i<ncandidates; i++) printf("lt %f cutvals %f lc %d cutidxs %d\n", leftTarget[i], cutvals[i], leftCount[i], cutidxs[i]);
 
     // Finally: See which cutoff has best information gain
     float crit = node->gini = wgtGini_(0, 0, 0, sumTarget, sumSqrTarget, usedN);
 
     int bestidx = -1;
     for (int i = 0; i < ncandidates; i++) {
-        int l=lC[i]; int r=usedN-lC[i];
+        int l=leftCount[i]; int r=usedN-leftCount[i];
         int min_size = max(int(usedN*0.05), parent->MIN_NODE/3);
         if (l<min_size || r<min_size) {
             //printf("XXX l %d r %d ci %d cu %f \n", l, r, cutidxs[i], cutvals[i]);
             continue;
         }
-        auto g = wgtGini_(lT[i], lT2[i], l, sumTarget, sumSqrTarget, usedN);
-        //printf("   i %d g %f crit %f bestidx %d l %d r %d lt %f\n", i, g, crit, bestidx, l, r, lT[i]);
+        auto g = wgtGini_(leftTarget[i], leftSqrTarget[i], l, sumTarget, sumSqrTarget, usedN);
+        //printf("   i %d g %f crit %f bestidx %d l %d r %d lt %f\n", i, g, crit, bestidx, l, r, leftTarget[i]);
         if (g <= crit) continue;
-        //printf("***i %d g %f crit %f bestidx %d l %d r %d lt %f\n", i, g, crit, bestidx, l, r, lT[i]);
+        //printf("***i %d g %f crit %f bestidx %d l %d r %d lt %f\n", i, g, crit, bestidx, l, r, leftTarget[i]);
         crit = g; 
         bestidx = i;
     }
@@ -234,23 +234,23 @@ void FastTree::bestCutoff_(Node *node) {
     if (node->value<1)
         printf("*** n %d bp %d v %f sumTarget %f\n", n, node->bestPred, node->value, sumTarget);
     //printf("lt %f lc %d n %d crit %f gini %f bestidx %d bestPred %d cutoff %f value %f\n",
-            //lT[bestidx], lC[bestidx], usedN, crit, node->gini, bestidx, node->bestPred, node->cutoff, node->value);
+            //leftTarget[bestidx], leftCount[bestidx], usedN, crit, node->gini, bestidx, node->bestPred, node->cutoff, node->value);
 }
 
-void do_cutoffchk(int ncandidates, float* pred, float act, int* cutidxs, float* cutvals, float* lT, float* lT2, int* lC) {
+void do_cutoffchk(int ncandidates, float* pred, float act, int* cutidxs, float* cutvals, float* leftTarget, float* leftSqrTarget, int* leftCount) {
     //#pragma ivdep
     for (int i = 0; i < ncandidates; i++) {
         if (pred[cutidxs[i]] >= cutvals[i]) continue;
-        lT[i] += act;
-        lT2[i] += act*act;
-        lC[i]++;
+        leftTarget[i] += act;
+        leftSqrTarget[i] += act*act;
+        leftCount[i]++;
     }
 }
 
 void FastTree::checkCutoffs(int start, int n, int ncandidates) {
     //printf("b start %d n %d\n", start, n);
     for (int r = start; r < start + n; r++) {
-        do_cutoffchk(ncandidates, X[r], y[r], cutidxs, cutvals, lT, lT2, lC);
+        do_cutoffchk(ncandidates, X[r], y[r], cutidxs, cutvals, leftTarget, leftSqrTarget, leftCount);
     }
 }
 
@@ -266,16 +266,16 @@ bool FastTree::allSame_(Node *node) {
     return true;
 }
 
-float FastTree::wgtGini_(float cTarget, float cSqrTarget, float cCount, float sumTarget, float sumSqrTarget, float totCount) {
-    float l = gini_(cTarget, cSqrTarget, cCount);
-    float r = gini_(sumTarget - cTarget, sumSqrTarget - cSqrTarget, totCount - cCount);
-    float lProp = cCount/totCount;
-    float res = 0.0; 
+float FastTree::wgtGini_(float leftTarget, float leftSqrTarget, float leftCount, float sumTarget, float sumSqrTarget, float totCount) {
+    float l = gini_(leftTarget, leftSqrTarget, leftCount);
+    float r = gini_(sumTarget - leftTarget, sumSqrTarget - leftSqrTarget, totCount - leftCount);
+    float lProp = leftCount/totCount;
+    float result = 0.0;
 
     // avoids NaNs by checking size of segment
-    if (lProp > 0) res += l*lProp;
-    if (lProp < 1) res += r*(1 - lProp);
-    return res;
+    if (lProp > 0) result += l*lProp;
+    if (lProp < 1) result += r*(1 - lProp);
+    return result;
 }
 
 int FastTree::shuffle_(Node *node) {

--- a/cfastforest.cpp
+++ b/cfastforest.cpp
@@ -306,11 +306,13 @@ int FastTree::shuffle_(Node *node) {
 
 float FastTree::predict(float const *X) {
     Node* node = root;
-    int i=0;
-    while (node->bestPred >= 0 && i++<10000) {
+    const int FAILSAFE = 1000; // TODO: remove when done debugging
+	int i=0;                   // TODO: remove when done debugging
+    while ( node->bestPred >= 0 && i<FAILSAFE ) {
         node = (X[node->bestPred] < node->cutoff) ? node->left : node->right;
+        i++;
     }
-    if (i>1000) printf("************---\n");
+    if (i>FAILSAFE) printf("************---\n");
     return node->value;
 }
  

--- a/cfastforest.cpp
+++ b/cfastforest.cpp
@@ -9,11 +9,11 @@ FastForest* trainFF(float *X, float *y, int nrows, int ncols) {
     return ff;
 }
 
-Node::Node(int start, int n, Node* parent, bool isLeft) {
+Node::Node(int start, int nrows, Node* parent, bool isLeft) {
     bestPred = -1;
     value=gini=cutoff=0.0;
     this->start = start;
-    this->n = n;
+    this->nrows = nrows;
     this->isLeft = isLeft;
     if (parent == nullptr) return;
 
@@ -155,7 +155,7 @@ void FastTree::buildNodes_() {
         }
 
         int leftn = shuffle_(node);
-        int rightn = node->n - leftn;
+        int rightn = node->nrows - leftn;
         if (leftn == 0 || rightn == 0)
             printf("i %d l %d r %d\n", i, leftn, rightn); 
 
@@ -165,7 +165,7 @@ void FastTree::buildNodes_() {
 }
 
 void FastTree::bestCutoff_(Node *node) {
-    int n = node->n;
+    int n = node->nrows;
     auto start = node->start;
 	float sumTarget=0, sumSqrTarget=0;
 
@@ -256,7 +256,7 @@ void FastTree::checkCutoffs(int start, int n, int ncandidates) {
 }
 
 bool FastTree::allSame_(Node *node) {
-    int n = node->n;
+    int n = node->nrows;
     if (n > MAXN) n = MAXN;
     int start = node->start;
     int first = y[start]; // TODO: this has to be float
@@ -270,18 +270,18 @@ bool FastTree::allSame_(Node *node) {
 float FastTree::wgtGini_(float leftTarget, float leftSqrTarget, float leftCount, float sumTarget, float sumSqrTarget, float totCount) {
     float l = gini_(leftTarget, leftSqrTarget, leftCount);
     float r = gini_(sumTarget - leftTarget, sumSqrTarget - leftSqrTarget, totCount - leftCount);
-    float lProp = leftCount/totCount;
+    float lprop = leftCount/totCount;
     float result = 0.0;
 
     // avoids NaNs by checking size of segment
-    if (lProp > 0) result += l*lProp;
-    if (lProp < 1) result += r*(1 - lProp);
+    if (lprop > 0) result += l*lprop;
+    if (lprop < 1) result += r*(1 - lprop);
     return result;
 }
 
 int FastTree::shuffle_(Node *node) {
     int start = node->start;
-    int n = node->n, p = node->bestPred;
+    int n = node->nrows, p = node->bestPred;
     float cutoff = node->cutoff;
 
     int end = start + n;

--- a/cfastforest.cpp
+++ b/cfastforest.cpp
@@ -58,19 +58,10 @@ float* FastForest::predict(float *X, int nrows, int ncols) {
     return res; 
 }
 
-
-void FastTree::clearStorage_() {
-    _mm_free(leftSqrTarget); _mm_free(leftTarget); _mm_free(leftCount); _mm_free(cutvals); _mm_free(cutidxs);
-}
-
-void FastTree::reset(int ncandidates) {
-    for (int i = 0; i < ncandidates; i++) { leftSqrTarget[i]=leftTarget[i]=leftCount[i] = 0; }
-}
-
 FastTree::FastTree(FastForest* parent) {
     this->parent = parent;
     this->ncols = parent->ncols;
- 
+
     random_device rd;
     rng = new default_random_engine(rd());
 
@@ -88,6 +79,14 @@ FastTree::FastTree(FastForest* parent) {
 
 	buildNodes_();
 	clearStorage_();
+}
+
+void FastTree::clearStorage_() {
+	_mm_free(leftSqrTarget); _mm_free(leftTarget); _mm_free(leftCount); _mm_free(cutvals); _mm_free(cutidxs);
+}
+
+void FastTree::reset(int ncandidates) {
+	for (int i = 0; i < ncandidates; i++) { leftSqrTarget[i]=leftTarget[i]=leftCount[i] = 0; }
 }
 
 void FastTree::createIdxsAndOob_() {

--- a/cfastforest.cpp
+++ b/cfastforest.cpp
@@ -70,23 +70,19 @@ FastTree::FastTree(FastForest* parent) {
     int usedN = nrows > MAXN ? MAXN : nrows; // TODO: is this just min(ncols, MAXN)?
     int ncandidates = usedN * sqrt(ncols) / CUTOFF_DIVISOR;
     if (ncandidates < 4) ncandidates = 4;
-    //printf("nc %d\n",nc);
-    leftTarget = (float*)_mm_malloc(ncandidates * sizeof(float), 64);
-    leftSqrTarget = (float*)_mm_malloc(ncandidates * sizeof(float), 64);
-    cutvals = (float*)_mm_malloc(ncandidates * sizeof(float), 64);
-    leftCount = (int*)_mm_malloc(ncandidates * sizeof(int), 64);
-    cutidxs = (int*)_mm_malloc(ncandidates * sizeof(int), 64);
+    //printf("nc %d\n", ncandidates);
+    candInfo = (CandidateInfo *)_mm_malloc(ncandidates * sizeof(CandidateInfo), 64);
 
 	buildNodes_();
 	clearStorage_();
 }
 
 void FastTree::clearStorage_() {
-	_mm_free(leftSqrTarget); _mm_free(leftTarget); _mm_free(leftCount); _mm_free(cutvals); _mm_free(cutidxs);
+    _mm_free(candInfo);
 }
 
 void FastTree::reset(int ncandidates) {
-	for (int i = 0; i < ncandidates; i++) { leftSqrTarget[i]=leftTarget[i]=leftCount[i] = 0; }
+	for (int i = 0; i < ncandidates; i++) { candInfo[i].leftSqrTarget=candInfo[i].leftTarget=candInfo[i].leftCount = 0; }
 }
 
 void FastTree::createIdxsAndOob_() {
@@ -187,8 +183,8 @@ void FastTree::bestCutoff_(Node *node) {
     // TODO: Don't add cutoffs that aren't unique on both val and predidx
     for (int i = 0; i < ncandidates; i++) {
         auto predidx = gen3(*rng);
-        cutidxs[i] = predidx;
-        cutvals[i] = X[gen2(*rng)][predidx];
+        candInfo[i].cutidxs = predidx;
+        candInfo[i].cutvals = X[gen2(*rng)][predidx];
     }
 
     //printf("a start %d n %d usedN %d\n", start, n, usedN);
@@ -203,30 +199,30 @@ void FastTree::bestCutoff_(Node *node) {
         sumTarget += y[r]; sumSqrTarget += y[r]*y[r];
     }
     //printf("n %d start %d pn %d ncandidates %d sumTarget %d usedN %d MAXN %d c %d\n", n, start, parent->n, ncandidates, sumTarget, usedN, MAXN, c);
-    //for (int i=0; i<ncandidates; i++) printf("lt %f cutvals %f lc %d cutidxs %d\n", leftTarget[i], cutvals[i], leftCount[i], cutidxs[i]);
+    //for (int i=0; i<ncandidates; i++) printf("lt %f cutvals %f lc %d cutidxs %d\n", candInfo[i].leftTarget, candInfo[i].cutvals, candInfo[i].leftCount, candInfo[i].cutidxs);
 
     // Finally: See which cutoff has best information gain
     float crit = node->gini = wgtGini_(0, 0, 0, sumTarget, sumSqrTarget, usedN);
 
     int bestidx = -1;
     for (int i = 0; i < ncandidates; i++) {
-        int l=leftCount[i]; int r=usedN-leftCount[i];
+        int l=candInfo[i].leftCount; int r=usedN-candInfo[i].leftCount;
         int min_size = max(int(usedN*0.05), parent->MIN_NODE/3);
         if (l<min_size || r<min_size) {
             //printf("XXX l %d r %d ci %d cu %f \n", l, r, cutidxs[i], cutvals[i]);
             continue;
         }
-        auto g = wgtGini_(leftTarget[i], leftSqrTarget[i], l, sumTarget, sumSqrTarget, usedN);
-        //printf("   i %d g %f crit %f bestidx %d l %d r %d lt %f\n", i, g, crit, bestidx, l, r, leftTarget[i]);
+        auto g = wgtGini_(candInfo[i].leftTarget, candInfo[i].leftSqrTarget, l, sumTarget, sumSqrTarget, usedN);
+        //printf("   i %d g %f crit %f bestidx %d l %d r %d lt %f\n", i, g, crit, bestidx, l, r, candInfo[i].leftTarget);
         if (g <= crit) continue;
-        //printf("***i %d g %f crit %f bestidx %d l %d r %d lt %f\n", i, g, crit, bestidx, l, r, leftTarget[i]);
+        //printf("***i %d g %f crit %f bestidx %d l %d r %d lt %f\n", i, g, crit, bestidx, l, r, candInfo[i].leftTarget);
         crit = g; 
         bestidx = i;
     }
 
     if (bestidx >= 0) { // Did we make an improvement?
-        node->bestPred = cutidxs[bestidx];
-        node->cutoff = cutvals[bestidx];
+        node->bestPred = candInfo[bestidx].cutidxs;
+        node->cutoff = candInfo[bestidx].cutvals;
     }
 
     // Only approximate if sampled:
@@ -234,23 +230,24 @@ void FastTree::bestCutoff_(Node *node) {
     if (node->value<1)
         printf("*** n %d bp %d v %f sumTarget %f\n", n, node->bestPred, node->value, sumTarget);
     //printf("lt %f lc %d n %d crit %f gini %f bestidx %d bestPred %d cutoff %f value %f\n",
-            //leftTarget[bestidx], leftCount[bestidx], usedN, crit, node->gini, bestidx, node->bestPred, node->cutoff, node->value);
+            //candInfo[bestidx].leftTarget, candInfo[bestidx].leftCount, usedN, crit, node->gini, bestidx, node->bestPred, node->cutoff, node->value);
 }
 
-void do_cutoffchk(int ncandidates, float const * pred, float act, int const *cutidxs, float const *cutvals, float* leftTarget, float* leftSqrTarget, int* leftCount) {
+// TODO: is pred actually x (feature value)?
+void do_cutoffchk(int ncandidates, float const * pred, float target, CandidateInfo *candInfo) {
     //#pragma ivdep
     for (int i = 0; i < ncandidates; i++) {
-        if (pred[cutidxs[i]] >= cutvals[i]) continue;
-        leftTarget[i] += act;
-        leftSqrTarget[i] += act*act;
-        leftCount[i]++;
+        if (pred[candInfo[i].cutidxs] >= candInfo[i].cutvals) continue;
+        candInfo[i].leftTarget += target;
+        candInfo[i].leftSqrTarget += target*target;
+        candInfo[i].leftCount++;
     }
 }
 
 void FastTree::checkCutoffs(int start, int n, int ncandidates) {
     //printf("b start %d n %d\n", start, n);
     for (int r = start; r < start + n; r++) {
-        do_cutoffchk(ncandidates, X[r], y[r], cutidxs, cutvals, leftTarget, leftSqrTarget, leftCount);
+        do_cutoffchk(ncandidates, X[r], y[r], candInfo);
     }
 }
 

--- a/cfastforest.cpp
+++ b/cfastforest.cpp
@@ -75,12 +75,6 @@ FastTree::FastTree(FastForest* parent) {
 	buildNodes_();
 }
 
-inline void FastTree::reset(CandidateInfo *candInfo, int ncandidates) {
-	for (int i = 0; i < ncandidates; i++) {
-	    candInfo[i].leftSqrTarget = candInfo[i].leftTarget = candInfo[i].leftCount = 0;
-	}
-}
-
 void FastTree::createIdxsAndOob_() {
     // TODO: OOB
     nrows = 0;
@@ -174,7 +168,6 @@ void FastTree::bestCutoff_(Node *node) {
     if (ncandidates < 4) ncandidates = 4;
 
     CandidateInfo candInfo[ncandidates]; // Only works in GCC I think but that's ok as we rely on OpenMP in GCC also
-    reset(candInfo, ncandidates);
 
     uniform_int_distribution<int> gen2(start, start+n-1);
     uniform_int_distribution<int> gen3(0, ncols-1);

--- a/cfastforest.cpp
+++ b/cfastforest.cpp
@@ -1,9 +1,10 @@
+#include <mm_malloc.h>
 #include "cfastforest.hpp"
 
 using namespace std;
 
-FastForest* trainFF(float *x_, float *y, int r, int c) {
-    auto ff = new FastForest(x_, y, r, c);
+FastForest* trainFF(float *X, float *y, int nrows, int ncols) {
+    auto ff = new FastForest(X, y, nrows, ncols);
 	ff->build();
     return ff;
 }
@@ -22,8 +23,8 @@ Node::Node(int start, int n, Node* parent, bool isLeft) {
 
 bool Node::isTerminal() { return bestPred == -1; }
 
-FastForest::FastForest(float* X_, float* y_, int n_, int c_) {
-    c = c_; n = n_; X = X_; y = y_;
+FastForest::FastForest(float* X, float* y, int nrows, int ncols) {
+	this->nrows = nrows; this->ncols = ncols; this->X = X; this->y = y;
 }
 
 void FastForest::build() {
@@ -36,24 +37,24 @@ void FastForest::build() {
     }
 }
 
-float* FastForest::predict(float *rows, int n, int c) {
-    auto res = new float[n];
-    for (int i=0; i<n; i++) res[i]=0;
+float* FastForest::predict(float *X, int nrows, int ncols) {
+    auto res = new float[nrows];
+    for (int i=0; i<nrows; i++) res[i]=0;
 
     //#pragma omp parallel for  
     for (int i = 0; i < NTREE; i++) {
         auto tree = trees[i];
-        for (int j = 0; j < n; j++) {
-            auto predict = tree->predict(&rows[j * c]);
+        for (int j = 0; j < nrows; j++) {
+            auto predict = tree->predict(&X[j * ncols]);
             if (predict<1) printf("i %d j %d\n", i, j);
             //printf("- %f ",predict);
             //#pragma omp atomic
             res[j] += predict;
         }
-        //printf("\n");
+        //printf("\nrows");
     }
 
-    for (int j = 0; j < n; j++) {res[j] /= NTREE;}
+    for (int j = 0; j < nrows; j++) {res[j] /= NTREE;}
     return res; 
 }
 
@@ -68,15 +69,15 @@ void FastTree::reset(int ncandidates) {
 
 FastTree::FastTree(FastForest* parent) {
     this->parent = parent;
-    c = parent->c;
+    this->ncols = parent->ncols;
  
     random_device rd;
     rng = new default_random_engine(rd());
 
 	createIdxsAndOob_();  // NB: Only happens once per top-level tree
 
-    int usedN = n > MAXN ? MAXN : n;
-    int ncandidates = usedN * sqrt(c) / CUTOFF_DIVISOR;
+    int usedN = nrows > MAXN ? MAXN : nrows; // TODO: is this just min(ncols, MAXN)?
+    int ncandidates = usedN * sqrt(ncols) / CUTOFF_DIVISOR;
     if (ncandidates < 4) ncandidates = 4;
     //printf("nc %d\n",nc);
     leftTarget = (float*)_mm_malloc(ncandidates * sizeof(float), 64);
@@ -91,23 +92,23 @@ FastTree::FastTree(FastForest* parent) {
 
 void FastTree::createIdxsAndOob_() {
     // TODO: OOB
-    n = 0;
-    auto r = new float[parent->n];
+    nrows = 0;
+    auto r = new float[parent->nrows];
     uniform_real_distribution<float> gen(0.0f, 1.0f);
 
-    for (auto i = 0; i < parent->n; i++) {
+    for (auto i = 0; i < parent->nrows; i++) {
         r[i] = gen(*rng);
-        if (r[i] < parent->PROP_TRAIN) n++;
+        if (r[i] < parent->PROP_TRAIN) nrows++;
     }
 
-    X = new float*[n];
-    y = new float[n];
-    idxs = new int[n];
+    X = new float*[nrows];
+    y = new float[nrows];
+    idxs = new int[nrows];
     auto cur = 0;
-    for (auto i = 0; i < parent->n; i++) {
+    for (auto i = 0; i < parent->nrows; i++) {
         if (r[i] < parent->PROP_TRAIN)
         {
-            X[cur] = &(parent->X[i*c]);
+            X[cur] = &(parent->X[i*ncols]);
             y[cur] = parent->y[i];
             idxs[cur] = i;
             cur++;
@@ -121,7 +122,7 @@ void FastTree::createIdxsAndOob_() {
 void FastTree::shuffle() {
     uniform_real_distribution<float> gen(0.0f, 1.0f);
 
-    for (int i = n; i > 1; i--) {
+    for (int i = nrows; i > 1; i--) {
         // Pick random element to swap.
         auto j = (int)(gen(*rng) * i); // 0 <= j <= i-1
         // Swap
@@ -138,7 +139,7 @@ void FastTree::shuffle() {
 void FastTree::buildNodes_() {
     stack<Node*> s;
     // TODO: clean up Node memory on destruction
-    root = new Node(0, n, nullptr, true);
+    root = new Node(0, nrows, nullptr, true);
     s.push(root);
 
     int i=0;
@@ -178,12 +179,12 @@ void FastTree::bestCutoff_(Node *node) {
 
     // First: set up the cutoffs[]
     int usedN = n > MAXN ? MAXN : n;
-    int ncandidates = usedN * sqrt(c) / CUTOFF_DIVISOR;
+    int ncandidates = usedN * sqrt(ncols) / CUTOFF_DIVISOR;
     if (ncandidates < 4) ncandidates = 4;
 	reset(ncandidates);
 
     uniform_int_distribution<int> gen2(start, start+n-1);
-    uniform_int_distribution<int> gen3(0, c-1);
+    uniform_int_distribution<int> gen3(0, ncols-1);
     // TODO: Don't add cutoffs that aren't unique on both val and predidx
     for (int i = 0; i < ncandidates; i++) {
         auto predidx = gen3(*rng);
@@ -258,7 +259,7 @@ bool FastTree::allSame_(Node *node) {
     int n = node->n;
     if (n > MAXN) n = MAXN;
     int start = node->start;
-    int first = y[start];
+    int first = y[start]; // TODO: this has to be float
 
     for (int i = start + 1; i < start + n; i++)
         if (y[i] != first) return false;
@@ -303,11 +304,11 @@ int FastTree::shuffle_(Node *node) {
     return i-start;
 }
 
-float FastTree::predict(float * const arr) {
+float FastTree::predict(float const *X) {
     Node* node = root;
     int i=0;
     while (node->bestPred >= 0 && i++<10000) {
-        node = (arr[node->bestPred] < node->cutoff) ? node->left : node->right;
+        node = (X[node->bestPred] < node->cutoff) ? node->left : node->right;
     }
     if (i>1000) printf("************---\n");
     return node->value;

--- a/cfastforest.cpp
+++ b/cfastforest.cpp
@@ -3,7 +3,7 @@
 using namespace std;
 
 FastForest* trainFF(float *x_, float *y, int r, int c) {
-    FastForest* ff = new FastForest(x_, y, r, c);
+    auto ff = new FastForest(x_, y, r, c);
 	ff->build();
     return ff;
 }
@@ -237,7 +237,7 @@ void FastTree::bestCutoff_(Node *node) {
             //leftTarget[bestidx], leftCount[bestidx], usedN, crit, node->gini, bestidx, node->bestPred, node->cutoff, node->value);
 }
 
-void do_cutoffchk(int ncandidates, float* pred, float act, int* cutidxs, float* cutvals, float* leftTarget, float* leftSqrTarget, int* leftCount) {
+void do_cutoffchk(int ncandidates, float const * pred, float act, int const *cutidxs, float const *cutvals, float* leftTarget, float* leftSqrTarget, int* leftCount) {
     //#pragma ivdep
     for (int i = 0; i < ncandidates; i++) {
         if (pred[cutidxs[i]] >= cutvals[i]) continue;
@@ -303,7 +303,7 @@ int FastTree::shuffle_(Node *node) {
     return i-start;
 }
 
-float FastTree::predict(float *arr) {
+float FastTree::predict(float * const arr) {
     Node* node = root;
     int i=0;
     while (node->bestPred >= 0 && i++<10000) {

--- a/cfastforest.hpp
+++ b/cfastforest.hpp
@@ -60,17 +60,12 @@ public:
     float** X;  // rows subset used to train tree
     int* idxs;
     Node* root;
-	//_mm_free(leftSqrTarget); _mm_free(leftTarget); _mm_free(leftCount); _mm_free(cutvals); _mm_free(cutidxs);
-//    float *leftTarget, *leftSqrTarget, *cutvals;
-//    int *leftCount, *cutidxs;
-	CandidateInfo *candInfo;
 
-    void clearStorage_();
-    void reset(int ncandidates);
+    static void reset(CandidateInfo *candInfo, int ncandidates);
     void createIdxsAndOob_();
     void shuffle();
     void buildNodes_();
-    void checkCutoffs(int start, int n, int ncandidates);
+    void checkCutoffs(int start, int n, CandidateInfo *candInfo, int ncandidates);
     void bestCutoff_(Node *node);
     bool allSame_(Node *node);
     static float wgtGini_(float leftTarget, float leftSqrTarget, float leftCount, float sumTarget, float sumSqrTarget, float totCount);

--- a/cfastforest.hpp
+++ b/cfastforest.hpp
@@ -51,7 +51,7 @@ public:
     FastForest* parent;
     default_random_engine* rng;
     int c, n;
-    float* y;  // rows subset used to train tree
+    float* y;   // rows subset used to train tree
     float** X;  // rows subset used to train tree
     int* idxs;
     Node* root;

--- a/cfastforest.hpp
+++ b/cfastforest.hpp
@@ -46,6 +46,10 @@ public:
 struct CandidateInfo {
 	float leftTarget, leftSqrTarget, cutvals;
 	int leftCount, cutidxs;
+
+	// might be tiny bit slower to init with ctor vs iterating over array but
+	// we don't need reset() function this way.
+	CandidateInfo() { leftSqrTarget = leftTarget = leftCount = 0; }
 };
 
 class FastTree {
@@ -61,7 +65,6 @@ public:
     int* idxs;
     Node* root;
 
-    static void reset(CandidateInfo *candInfo, int ncandidates);
     void createIdxsAndOob_();
     void shuffle();
     void buildNodes_();

--- a/cfastforest.hpp
+++ b/cfastforest.hpp
@@ -55,8 +55,8 @@ public:
     float** X;  // rows subset used to train tree
     int* idxs;
     Node* root;
-    float *lT, *lT2, *cutvals;
-    int *lC, *cutidxs;
+    float *leftTarget, *leftSqrTarget, *cutvals;
+    int *leftCount, *cutidxs;
 
     void clearStorage_();
     void reset(int ncandidates);
@@ -66,7 +66,7 @@ public:
     void checkCutoffs(int start, int n, int ncandidates);
     void bestCutoff_(Node *node);
     bool allSame_(Node *node);
-    static float wgtGini_(float cTarget, float cSqrTarget, float cCount, float sumTarget, float sumSqrTarget, float totCount);
+    static float wgtGini_(float leftTarget, float leftSqrTarget, float leftCount, float sumTarget, float sumSqrTarget, float totCount);
     int shuffle_(Node *node);
     float predict(float *arr);
 };

--- a/cfastforest.hpp
+++ b/cfastforest.hpp
@@ -34,13 +34,13 @@ public:
     const float PROP_TRAIN = 0.8, PROP_OOB = 0.5;
 
     float *X,*y;
-    int n,c;
+    int nrows, ncols;
 
     FastTree** trees;
 
-    FastForest(float* X_, float* y_, int n_, int c_);
+    FastForest(float *X, float* y, int nrows, int ncols);
     void build();
-    float* predict(float *rows, int n, int c);
+    float* predict(float *X, int nrows, int ncols);
 };
 
 class FastTree {
@@ -50,7 +50,7 @@ public:
 
     FastForest* parent;
     default_random_engine* rng;
-    int c, n;
+	int nrows, ncols;
     float* y;   // rows subset used to train tree
     float** X;  // rows subset used to train tree
     int* idxs;
@@ -68,10 +68,10 @@ public:
     bool allSame_(Node *node);
     static float wgtGini_(float leftTarget, float leftSqrTarget, float leftCount, float sumTarget, float sumSqrTarget, float totCount);
     int shuffle_(Node *node);
-    float predict(float *arr);
+    float predict(float const *X);
 };
 
-FastForest* trainFF(float *x_, float *y, int r, int c);
+FastForest* trainFF(float *X, float *y, int nrows, int ncols);
 
 template <typename T> double stdev(T b, T e);
 float gini_(float sumTarget, float sumSqrTarget, float n);

--- a/cfastforest.hpp
+++ b/cfastforest.hpp
@@ -43,6 +43,11 @@ public:
     float* predict(float *X, int nrows, int ncols);
 };
 
+struct CandidateInfo {
+	float leftTarget, leftSqrTarget, cutvals;
+	int leftCount, cutidxs;
+};
+
 class FastTree {
 public:
     const int MAXN = 160, CUTOFF_DIVISOR = 10;
@@ -55,8 +60,10 @@ public:
     float** X;  // rows subset used to train tree
     int* idxs;
     Node* root;
-    float *leftTarget, *leftSqrTarget, *cutvals;
-    int *leftCount, *cutidxs;
+	//_mm_free(leftSqrTarget); _mm_free(leftTarget); _mm_free(leftCount); _mm_free(cutvals); _mm_free(cutidxs);
+//    float *leftTarget, *leftSqrTarget, *cutvals;
+//    int *leftCount, *cutidxs;
+	CandidateInfo *candInfo;
 
     void clearStorage_();
     void reset(int ncandidates);

--- a/cfastforest.hpp
+++ b/cfastforest.hpp
@@ -19,10 +19,10 @@ class Node {
 public:
     struct Node *left, *right;
     bool isLeft;
-    int start, n, bestPred;
+    int start, nrows, bestPred;
     float cutoff, value, gini;
 
-    Node(int start, int n, Node *parent, bool isLeft);
+    Node(int start, int nrows, Node *parent, bool isLeft);
     bool isTerminal();
 };
 

--- a/fastforest.pyx
+++ b/fastforest.pyx
@@ -1,4 +1,5 @@
 # distutils: language = c++
+# cython: language_level=3
 # distutils: sources = cfastforest.cpp
 
 import pandas as pd, numpy as np

--- a/fastforest.pyx
+++ b/fastforest.pyx
@@ -14,7 +14,7 @@ cdef extern from "cfastforest.hpp":
         Node *left
         Node *right
         bool isLeft
-        int start, n, bestPred
+        int start, nrows, bestPred
         float cutoff, value, gini
     cdef cppclass FastForest:
         FastTree** trees
@@ -42,7 +42,7 @@ cdef class PyNode:
     @property
     def start(self): return self.ptr.start
     @property
-    def n(self): return self.ptr.n
+    def n(self): return self.ptr.nrows
     @property
     def bestPred(self): return self.ptr.bestPred
     @property

--- a/fastforest.pyx
+++ b/fastforest.pyx
@@ -9,7 +9,7 @@ from libcpp cimport bool
 np.import_array()
 
 cdef extern from "cfastforest.hpp":
-    FastForest* trainFF(float *x_, float *y, int r, int c)
+    FastForest* trainFF(float *x_, float *y, int nrows, int ncols)
     cdef cppclass Node:
         Node *left
         Node *right
@@ -18,10 +18,10 @@ cdef extern from "cfastforest.hpp":
         float cutoff, value, gini
     cdef cppclass FastForest:
         FastTree** trees
-        int n
-        float* predict(float* rows, int n, int c)
+        int nrows, ncols
+        float* predict(float* rows, int nrows, int ncols)
     cdef cppclass FastTree:
-        int n
+        int nrows, ncols
         Node* root
         float predict(float* arr)
 
@@ -62,12 +62,12 @@ cdef class PyFastTree:
 cdef class PyFastForest:
     cdef FastForest *ptr
     def __cinit__(self, x, y):
-        n,c = x.shape
+        nrows, ncols = x.shape
         x = np.ascontiguousarray(x).astype(np.float32)
         cdef float [:,:] xv = x
         y = np.ascontiguousarray(y).astype(np.float32)
         cdef float [:] yv = y
-        self.ptr = trainFF(&xv[0,0], &yv[0], n, c)
+        self.ptr = trainFF(&xv[0,0], &yv[0], nrows, ncols)
 
     def get_tree(self,i):
         res = PyFastTree()


### PR DESCRIPTION
(includes previous renaming pull request. i can rebase if you accept previous. hard to see new changes otherwise.)

Removed parallel arrays and made array of struct `CandidateInfo`.
Removed all associated management functions as we can now do:

```
CandidateInfo candInfo[ncandidates];
```

That var len array only works in GCC, not clang.
