### PR TITLE
small var renaming, some with large fan out

### DIFF
--- a/fastforest.hpp
+++ b/fastforest.hpp
@@ -51,8 +51,8 @@ public:
 };
 
 struct CandidateInfo {
-    float leftTarget, leftSqrTarget, cutvals;
-    int leftCount, cutidxs;
+    float leftTarget, leftSqrTarget, cutval;
+    int leftCount, cutcol;
 
     // might be tiny bit slower to init with ctor vs iterating over array but
     // we don't need reset() function this way.


### PR DESCRIPTION
remove plural from cand info struct fields.
rename cand info struct field cutidx to be cutcol, mirroring cutval and being more explicit about idx of what
fix a few tab vs spaces
name all genX() random generators to be colgen, rowgen, etc... based upon usage.