### PR TITLE
Rm is left

### DIFF
--- a/fastforest.cpp
+++ b/fastforest.cpp
@@ -8,16 +8,12 @@ FastForest* trainFF(Mat X, Vec y) {
     return ff;
 }
 
-Node::Node(int start, int nrows, Node* parent, bool isLeft) {
+Node::Node(int start, int nrows, Node* parent) {
     bestPred = -1;
     value=gini=cutoff=0.0;
     this->start = start;
     this->nrows = nrows;
-    this->isLeft = isLeft;
     if (parent == nullptr) return;
-
-    if (isLeft) parent->left = this;
-    else parent->right = this;
 }
 
 bool Node::isTerminal() { return bestPred == -1; }
@@ -126,7 +122,7 @@ void FastTree::shuffle() {
 void FastTree::buildNodes_() {
     stack<Node*> s;
     // TODO: clean up Node memory on destruction
-    root = new Node(0, nrows, nullptr, true);
+    root = new Node(0, nrows, nullptr);
     s.push(root);
 
     int i=0;
@@ -146,8 +142,10 @@ void FastTree::buildNodes_() {
         if (leftn == 0 || rightn == 0)
             printf("i %d l %d r %d\n", i, leftn, rightn);
 
-        s.push(new Node(node->start+leftn, rightn, node, false));
-        s.push(new Node(node->start, leftn, node, true));
+		node->left = new Node(node->start, leftn, node);
+		node->right = new Node(node->start+leftn, rightn, node);
+        s.push(node->right);
+        s.push(node->left);
     }
 }
 

--- a/fastforest.cpp
+++ b/fastforest.cpp
@@ -142,8 +142,8 @@ void FastTree::buildNodes_() {
         if (leftn == 0 || rightn == 0)
             printf("i %d l %d r %d\n", i, leftn, rightn);
 
-		node->left = new Node(node->start, leftn, node);
-		node->right = new Node(node->start+leftn, rightn, node);
+        node->left = new Node(node->start, leftn, node);
+        node->right = new Node(node->start+leftn, rightn, node);
         s.push(node->right);
         s.push(node->left);
     }

--- a/fastforest.hpp
+++ b/fastforest.hpp
@@ -23,11 +23,10 @@ using Vec = Eigen::ArrayXf;
 class Node {
 public:
     struct Node *left, *right;
-    bool isLeft;
     int start, nrows, bestPred;
     float cutoff, value, gini;
 
-    Node(int start, int nrows, Node *parent, bool isLeft);
+    Node(int start, int nrows, Node *parent);
     bool isTerminal();
 };
 

--- a/fastforest_py.cpp
+++ b/fastforest_py.cpp
@@ -8,7 +8,6 @@ PYBIND11_MODULE(fastforest, m) {
     py::class_<Node>(m, "Node")
         .def_readonly("left", &Node::left)
         .def_readonly("right", &Node::right)
-        .def_readonly("isLeft", &Node::isLeft)
         .def_readonly("start", &Node::start)
         .def_readonly("nrows", &Node::nrows)
         .def_readonly("bestPred", &Node::bestPred)


### PR DESCRIPTION
I couldn't find a need for isLeft field and I wasn't sure it was a good idea to have a constructor modify the parent node.  possibly better to have explicit linking of parent and child. isLeft seemed an awkward way to handle that. At the very least, it wasn't needed as a field at least in the current code base.